### PR TITLE
fix(twineparser): get_all_filepath

### DIFF
--- a/src/core/parser/twine.py
+++ b/src/core/parser/twine.py
@@ -58,7 +58,7 @@ class TwineParser(Parser):
     def get_all_passages_info(self) -> list[PassageModel]:
         """Get all passages' info from twinescript files."""
         all_passages: list[PassageModel] = []
-        for filepath in self.all_filepaths:
+        for filepath in self.get_all_filepaths():
             with open(filepath, "r", encoding="utf-8") as fp:
                 content = fp.read()
 
@@ -346,3 +346,9 @@ class TwineParser(Parser):
 __all__ = [
     "TwineParser"
 ]
+
+
+if __name__ == '__main__':
+    parser = TwineParser()
+    parser.get_all_passages_info()
+    parser.get_all_elements_info()


### PR DESCRIPTION
## Sourcery 总结

修复 `TwineParser` 中的文件路径迭代，并添加一个 CLI 入口点以便快速执行

Bug 修复:
- 修复 `get_all_passages_info`，使其迭代 `get_all_filepaths` 的结果，而非一个静态属性

增强功能:
- 添加一个 `__main__` 块，以允许独立执行通道和元素信息提取

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix file path iteration in TwineParser and add a CLI entry point for quick execution

Bug Fixes:
- Fix get_all_passages_info to iterate over the results of get_all_filepaths rather than a static attribute

Enhancements:
- Add a __main__ block to allow standalone execution of passage and element info extraction

</details>